### PR TITLE
Fix potential file-include vulnerability

### DIFF
--- a/include/layout.inc
+++ b/include/layout.inc
@@ -396,7 +396,7 @@ function print_view($templateName, array $params = array()) {
     $path = $_SERVER['DOCUMENT_ROOT'] . '/views/' . $templateName;
     if(file_exists($path)) {
         if(!empty($params)) {
-            extract($params);
+            extract($params, EXTR_SKIP);
         }
         include_once $path;
     }


### PR DESCRIPTION
Fix potential file-include vulnerability by adding `EXTR_SKIP` to extract so it doesn't overwrite `$params` array.

WARNING: I have only proved this correct, I have not tested it
